### PR TITLE
clear the "changed" flag, as it's not automatically done by the reactive framework

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -14,6 +14,7 @@ class RedisRequires(Endpoint):
     def changed(self):
         if any(unit.received['port'] for unit in self.all_joined_units):
             set_flag(self.expand_name('available'))
+        clear_flag(self.expand_name('changed'))
 
     @when_not('endpoint.{endpoint_name}.joined')
     def broken(self):


### PR DESCRIPTION
Without this, the sentry charm (for example) will restart sentry every time a hook is run (including update-status).